### PR TITLE
Add ejentum-mcp to Tools & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ AI agents increasingly use external tools, plugins, and skills to interact with 
 | **[AgentSkillsScanner](https://github.com/sumleo/AgentSkillsScanner)** | Static analysis scanner for agent skill definitions | [![GitHub](https://img.shields.io/github/stars/sumleo/AgentSkillsScanner)](https://github.com/sumleo/AgentSkillsScanner) |
 | **[Agent Audit](https://arxiv.org/abs/2603.22853)** | Security analysis system for LLM agent apps: dataflow analysis, credential detection, MCP config parsing, privilege-risk checks | [Zhang et al.](https://arxiv.org/abs/2603.22853) |
 | **[mcp-sec-audit](https://arxiv.org/abs/2603.21641)** | MCP server security toolkit: static pattern matching + dynamic sandboxed fuzzing via Docker/eBPF for detecting over-privileged tool capabilities | [Huang et al.](https://arxiv.org/abs/2603.21641) |
+| **[ejentum-mcp](https://github.com/ejentum/ejentum-mcp)** | Reasoning harness exposing four agentic tools (reasoning, code, anti-deception, memory) the agent calls during its loop; the anti-deception scaffold targets sycophancy, hallucination, authority-appeal capitulation, and prompt-injection susceptibility | [![GitHub](https://img.shields.io/github/stars/ejentum/ejentum-mcp)](https://github.com/ejentum/ejentum-mcp) |
 
 ## Agent Skill Specifications
 


### PR DESCRIPTION
Adds `ejentum-mcp` to the **Tools & Frameworks** table.

`ejentum-mcp` is a reasoning harness exposed as an MCP server. Four agentic tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`) the agent calls during its reasoning loop. Each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally before producing its user-facing answer.

For the agent-skills-security audience, the `harness_anti_deception` mode is the relevant entry point: it gives the agent a tool that catches sycophancy, hallucination, authority-appeal capitulation, and prompt-injection susceptibility patterns by delivering an integrity scaffold the model absorbs before responding (different layer from filter/firewall tools like Pipelock, Invariant Guardrails, or LLM Guard).

- Source: https://github.com/ejentum/ejentum-mcp
- npm: https://www.npmjs.com/package/ejentum-mcp
- Hosted: https://api.ejentum.com/mcp
- Twelve native framework integrations on PyPI/npm
- Paper: ["Under Pressure" (Zenodo)](https://doi.org/10.5281/zenodo.19392715)
- License: MIT

Format matches existing **Tools & Frameworks** table entries.