### PR TITLE
Add Bounty Sieve guardrail tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ AI agents increasingly use external tools, plugins, and skills to interact with 
 
 | Tool | Description | Link |
 |------|-------------|------|
+| **[Bounty Sieve](https://github.com/junbuilds96/bounty-sieve)** | Offline-by-default bounty intake guardrail for coding agents: read-only GitHub issue/URL-list import, deterministic triage, local decision briefs, and human approval gates | [![GitHub](https://img.shields.io/github/stars/junbuilds96/bounty-sieve)](https://github.com/junbuilds96/bounty-sieve) |
 | **[SkillGuard](https://github.com/LLMSecurity/skillguard)** | LLM-native agent skill security auditor (OWASP Agentic + MITRE ATLAS) | [![GitHub](https://img.shields.io/github/stars/LLMSecurity/skillguard)](https://github.com/LLMSecurity/skillguard) |
 | **[Pipelock](https://github.com/luckyPipewrench/pipelock)** | Open-source AI agent firewall and MCP-aware egress proxy with DLP, prompt injection scanning, process sandboxing, and mediator-signed action receipts | [![GitHub](https://img.shields.io/github/stars/luckyPipewrench/pipelock)](https://github.com/luckyPipewrench/pipelock) |
 | **[Invariant Guardrails](https://github.com/invariantlabs-ai/invariant)** | Policy-based agent security guardrails | [![GitHub](https://img.shields.io/github/stars/invariantlabs-ai/invariant)](https://github.com/invariantlabs-ai/invariant) |


### PR DESCRIPTION
## Resource Addition

**Category:** Tools and Frameworks
**Type:** Tool

### Resource Details
- **Title:** Bounty Sieve
- **URL:** https://github.com/junbuilds96/bounty-sieve
- **Authors/Source:** junbuilds96
- **Year:** 2026

### Why This Should Be Included
Bounty Sieve is directly related to agent, tool, and skill security because it gives coding agents a read-only intake gate before they act on bounty-like GitHub issues. It helps catch prompt/context exfiltration, credential/wallet requests, star-gated tasks, duplicate-PR traps, and vague high-reward work before the agent clones code, comments, claims work, or opens PRs.

It ships a SKILL.md, explicit human approval gates, offline fixtures, GitHub issue and URL-list import, deterministic triage, and local decision briefs.

### Checklist
- [x] Resource is directly related to agent/tool/skill security
- [x] Not already listed in the README
- [x] Follows the formatting guidelines in CONTRIBUTING.md
- [x] Link is accessible and working
