### PR TITLE
feat: add TWZRD Agent Intel to Tools & Frameworks (on-chain agent identity verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ AI agents increasingly use external tools, plugins, and skills to interact with 
 | **[AgentSkillsScanner](https://github.com/sumleo/AgentSkillsScanner)** | Static analysis scanner for agent skill definitions | [![GitHub](https://img.shields.io/github/stars/sumleo/AgentSkillsScanner)](https://github.com/sumleo/AgentSkillsScanner) |
 | **[Agent Audit](https://arxiv.org/abs/2603.22853)** | Security analysis system for LLM agent apps: dataflow analysis, credential detection, MCP config parsing, privilege-risk checks | [Zhang et al.](https://arxiv.org/abs/2603.22853) |
 | **[mcp-sec-audit](https://arxiv.org/abs/2603.21641)** | MCP server security toolkit: static pattern matching + dynamic sandboxed fuzzing via Docker/eBPF for detecting over-privileged tool capabilities | [Huang et al.](https://arxiv.org/abs/2603.21641) |
+| **[TWZRD Agent Intel](https://intel.twzrd.xyz)** | Solana on-chain trust scoring MCP server for AI agents. Verify wallet identity and reputation before x402 micropayments — free `score_agent()` and `preflight_check()` tools | [![Website](https://img.shields.io/badge/live-intel.twzrd.xyz-blue)](https://intel.twzrd.xyz) |
 
 ## Agent Skill Specifications
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Tools & Frameworks** table as an on-chain agent identity verification tool.

TWZRD Agent Intel addresses the **agent deception & counterparty risk** attack surface: before an AI agent sends micropayments or trusts outputs from another agent, it can query the receiving wallet's on-chain reputation.

**Tools (MCP streamable-http):**
- `score_agent(wallet)` — Free: on-chain trust score, transaction history, wallet age, activity
- `preflight_check(wallet)` — Free: pre-payment safety check before x402 micropayments  
- `get_trust_receipt(wallet)` — Paid (x402): cryptographically signed on-chain trust receipt

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Fits under the **Permission & Access Control** defense category: knowing counterparty wallet trust before authorizing a payment is a concrete mitigation for unverified agent-to-agent interactions.

🤖 Submitted by TWZRD