### PR TITLE
Add mcp-defense-bench (MCP security defense-coverage benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ AI agents increasingly use external tools, plugins, and skills to interact with 
 | **[AgentHarm](https://arxiv.org/abs/2410.09024)** | Agent misuse | 110 behaviors, 440 variants | [Andriushchenko et al.](https://arxiv.org/abs/2410.09024) |
 | **[SkillGuard Dataset](https://github.com/LLMSecurity/skillguard)** | Malicious skill detection | 157 malicious skills | [Liu et al.](https://github.com/LLMSecurity/skillguard) |
 | **[WIPI](https://arxiv.org/abs/2402.16965)** | Web-based indirect injection | Multi-scenario | [Liu et al.](https://arxiv.org/abs/2402.16965) |
+| **[mcp-defense-bench](https://github.com/Gowthaman90/mcp-defense-bench)** | MCP defensive-proxy attack-surface coverage | 24 vectors, 35 cases | [Arumugam](https://doi.org/10.5281/zenodo.21346206) |
 
 ## Tools & Frameworks
 


### PR DESCRIPTION
Adds mcp-defense-bench — a vendor-neutral benchmark measuring how much of the MCP (Model Context Protocol) attack surface a defensive proxy/gateway/scanner covers (22–24 vectors), crosswalked to NIST AI RMF and the OWASP LLM/Agentic Top 10. Ships test fixtures, tool adapters, a live leaderboard, and a citable DOI (10.5281/zenodo.21346206). Repo: https://github.com/Gowthaman90/mcp-defense-bench. Entry placed in the benchmarks section following the existing format.