### PR TITLE
Add ClawBench to security benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ AI agents increasingly use external tools, plugins, and skills to interact with 
 
 | Benchmark | Focus | Size | Paper |
 |-----------|-------|------|-------|
+| **[ClawBench](https://github.com/reacher-z/ClawBench)** | Safe real-world web-agent evaluation | 153 tasks, 144 production websites | [Zhang et al.](https://arxiv.org/abs/2604.08523) |
 | **[ASB](https://github.com/agiresearch/ASB)** | Comprehensive agent security | 10 agents, 398 envs | [Zhang et al.](https://arxiv.org/abs/2410.02644) |
 | **[InjecAgent](https://github.com/uiuc-kang-lab/InjecAgent)** | Indirect prompt injection | 1,054 test cases | [Zhan et al.](https://arxiv.org/abs/2403.02691) |
 | **[R-Judge](https://github.com/Lordog/R-Judge)** | Safety risk awareness | 162 records, 27 scenarios | [Yuan et al.](https://arxiv.org/abs/2401.10019) |


### PR DESCRIPTION
Adds ClawBench to the Benchmarks & Datasets table. ClawBench evaluates browser agents on 283 V1+V2 everyday tasks across 163 live websites and uses submission-request interception to prevent real-world side effects while preserving execution evidence, making it relevant to safe agent evaluation. Submitted by reacher-z (mtrxcop@gmail.com), a ClawBench maintainer.